### PR TITLE
feat: rename --import-helpers flag to --helpers with backward compatibility

### DIFF
--- a/pkg/cmd/generate/generate_test.go
+++ b/pkg/cmd/generate/generate_test.go
@@ -1,8 +1,11 @@
 package generate
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -452,4 +455,82 @@ Hello, {{properties.name}}!`))
 	assert.NoError(t, err)
 	assert.Equal(t, `@gencoder.generated: test1.txt
 Hello, World!`, string(content))
+}
+
+func TestNewCmdGenerate_whenHelpersIsSet_thenShouldRegisterCustomHelpers(t *testing.T) {
+	workDir, err := os.MkdirTemp("", "test")
+	require.NoError(t, err)
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			t.Fatalf("failed to remove temp dir: %s", err)
+		}
+	}(workDir)
+
+	_ = os.Chdir(workDir)
+
+	createNewFile(filepath.Join(workDir, "gencoder.yaml"), []byte(`
+templates: templates
+`))
+	createNewFile(filepath.Join(workDir, "templates/test1.text.hbs"), []byte(`@gencoder.generated: test1.txt
+Hello, {{_toUpperCase properties.name}}!`))
+	createNewFile(filepath.Join(workDir, "helpers.js"), []byte(`
+Handlebars.registerHelper('_toUpperCase', function (target) {
+	return target.toUpperCase();
+});
+`))
+
+	cmd := NewCmdGenerate(&model.GlobalOptions{})
+	cmd.SetArgs([]string{"--config", "gencoder.yaml", "--properties", "name=World", "--helpers", "helpers.js"})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(workDir, "test1.txt"))
+	assert.NoError(t, err)
+	assert.Equal(t, `@gencoder.generated: test1.txt
+Hello, WORLD!`, string(content))
+}
+
+func TestNewCmdGenerate_whenImportHelpersIsUsed_thenShouldShowDeprecationWarning(t *testing.T) {
+	workDir, err := os.MkdirTemp("", "test")
+	require.NoError(t, err)
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			t.Fatalf("failed to remove temp dir: %s", err)
+		}
+	}(workDir)
+
+	_ = os.Chdir(workDir)
+
+	createNewFile(filepath.Join(workDir, "gencoder.yaml"), []byte(`
+templates: templates
+`))
+	createNewFile(filepath.Join(workDir, "templates/test1.text.hbs"), []byte(`@gencoder.generated: test1.txt
+Hello, {{properties.name}}!`))
+	createNewFile(filepath.Join(workDir, "helpers.js"), []byte(`
+// Empty helper file for testing
+`))
+
+	// Capture stderr to check for deprecation warning
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	cmd := NewCmdGenerate(&model.GlobalOptions{})
+	cmd.SetArgs([]string{"--config", "gencoder.yaml", "--properties", "name=World", "--import-helpers", "helpers.js"})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	// Restore stderr and read captured output
+	_ = w.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	stderrOutput := buf.String()
+
+	// Check that deprecation warning was shown
+	assert.True(t, strings.Contains(stderrOutput, "Warning: --import-helpers flag is deprecated, please use --helpers instead"))
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -23,9 +23,9 @@ func NewCmdRoot(buildInfo *model.BuildInfo) *cobra.Command {
 
   # Generate code from a template project with custom properties
   $ gencoder generate --templates "https://github.com/user/template-project" --properties "package=com.example,author=Freeman" --include-non-tpl
-  
+
   # Generate code using custom helpers, build-in helpers: https://github.com/DanielLiu1123/gencoder/blob/main/pkg/jsruntime/helper.js
-  $ gencoder generate --import-helpers helpers.js
+  $ gencoder generate --helpers helpers.js
 
   # Init basic config for quick start
   $ gencoder init


### PR DESCRIPTION
## Summary

This PR renames the `--import-helpers` flag to `--helpers` while maintaining full backward compatibility.

## Changes

### New Features
- ✅ Added new `--helpers` flag as the preferred option
- ✅ Maintained `--import-helpers` flag for backward compatibility
- ✅ Added deprecation warning when using the old flag
- ✅ Updated all command examples to use the new flag

### Implementation Details
- Both flags point to the same `importHelpers` field ensuring identical functionality
- Deprecation warning is shown via stderr when `--import-helpers` is used
- Warning message: `Warning: --import-helpers flag is deprecated, please use --helpers instead`
- Help text clearly marks the old flag as deprecated

### Testing
- ✅ Added comprehensive test coverage for new flag functionality
- ✅ Added test for deprecation warning mechanism
- ✅ Verified all existing tests continue to pass
- ✅ Manual testing confirms both flags work identically

## Backward Compatibility

**No breaking changes** - existing scripts and workflows using `--import-helpers` will continue to work exactly as before, with only an additional warning message.

## Migration Path

Users can gradually migrate from:
```bash
gencoder generate --import-helpers helpers.js
```

To:
```bash
gencoder generate --helpers helpers.js
```

## Files Modified

- `pkg/cmd/generate/generate.go` - Added new flag, deprecation warning, updated examples
- `pkg/cmd/root.go` - Updated root command examples
- `pkg/cmd/generate/generate_test.go` - Added comprehensive test coverage

## Testing

All tests pass:
```bash
go test ./pkg/cmd/generate/... -v
```

Manual verification:
- ✅ New `--helpers` flag works correctly
- ✅ Old `--import-helpers` flag works with deprecation warning
- ✅ Help documentation shows both flags appropriately
- ✅ Generated output is identical for both flags

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author